### PR TITLE
Add simple voice recorder to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@ This repository contains a minimal voice AI application consisting of a Next.js 
 
 ## Frontend
 The `frontend` directory holds a TypeScript based Next.js project. Tailwind CSS is configured for styling and the project is ready for integrating the [shadcn/ui](https://ui.shadcn.com) component library.
+The homepage now includes a simple voice recorder that sends transcripts to the backend.
 
 ```bash
 cd frontend
 npm install
 npm run dev
 ```
+Set `BACKEND_URL` in an `.env` file if the FastAPI server runs on a different host or port.
+
 
 Run tests:
 ```bash

--- a/frontend/app/api/transcribe/route.ts
+++ b/frontend/app/api/transcribe/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  const backendUrl = process.env.BACKEND_URL ?? "http://localhost:8000/transcribe";
+  const res = await fetch(backendUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  const result = await res.json();
+  return NextResponse.json(result);
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,10 +1,12 @@
 import { Button } from "../components/ui/button";
+import VoiceRecorder from "../components/VoiceRecorder";
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-24 gap-4">
       <h1 className="text-2xl font-bold">Gistly Voice AI</h1>
       <Button>Example Button</Button>
+      <VoiceRecorder />
     </main>
   );
 }

--- a/frontend/components/VoiceRecorder.tsx
+++ b/frontend/components/VoiceRecorder.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { Button } from "./ui/button";
+
+export default function VoiceRecorder() {
+  const [recording, setRecording] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+
+  const startRecording = () => {
+    const SpeechRecognition =
+      (window as any).SpeechRecognition ||
+      (window as any).webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      alert("Speech recognition not supported in this browser");
+      return;
+    }
+    const recognition: SpeechRecognition = new SpeechRecognition();
+    recognition.lang = "en-US";
+    recognition.interimResults = false;
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const text = event.results[0][0].transcript;
+      setTranscript(text);
+    };
+    recognition.onend = () => {
+      setRecording(false);
+      sendTranscript();
+    };
+    recognitionRef.current = recognition;
+    setRecording(true);
+    recognition.start();
+  };
+
+  const stopRecording = () => {
+    recognitionRef.current?.stop();
+  };
+
+  const sendTranscript = async () => {
+    if (!transcript) return;
+    try {
+      const res = await fetch("/api/transcribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: transcript }),
+      });
+      const data = await res.json();
+      setTranscript(data.transcript);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <Button onClick={recording ? stopRecording : startRecording}>
+        {recording ? "Stop Recording" : "Start Recording"}
+      </Button>
+      {transcript && <p className="mt-4">{transcript}</p>}
+    </div>
+  );
+}

--- a/frontend/tests/example.spec.ts
+++ b/frontend/tests/example.spec.ts
@@ -3,4 +3,5 @@ import { test, expect } from '@playwright/test';
 test('homepage has title', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('h1')).toHaveText('Gistly Voice AI');
+  await expect(page.getByRole('button', { name: 'Start Recording' })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add a `VoiceRecorder` component that uses the Web Speech API
- forward `/api/transcribe` requests to the FastAPI backend
- render the recorder on the homepage
- document how to configure the backend URL
- update Playwright test to check for the recorder button

## Testing
- `npm test --prefix frontend`
- `pytest -q backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68518fb106408328bff0a70b4133e88d